### PR TITLE
Add script assembly

### DIFF
--- a/Assets/Scripts/Scripts.asmdef
+++ b/Assets/Scripts/Scripts.asmdef
@@ -1,0 +1,27 @@
+{
+    "name": "Scripts",
+    "rootNamespace": "",
+    "references": [
+        "Unity.TextMeshPro"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [
+        "Android",
+        "CloudRendering",
+        "Editor",
+        "iOS",
+        "PS4",
+        "Stadia",
+        "Switch",
+        "tvOS",
+        "WebGL",
+        "XboxOne"
+    ],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/Scripts.asmdef.meta
+++ b/Assets/Scripts/Scripts.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 596fef460276dfe32bfe9a4a35718bdc
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Removing Gaiagaia allows a proper use of a script assembly, which is mandatory for using external packages. Introducing it earlier will minimize problems later on.

This depends on #303 